### PR TITLE
Add pageScroll to new fabric point in resizecanvas

### DIFF
--- a/openseadragon-fabricjs-overlay.js
+++ b/openseadragon-fabricjs-overlay.js
@@ -110,7 +110,9 @@
            var y=Math.round(image1WindowPoint.y);
            var canvasOffset=this._canvasdiv.getBoundingClientRect();
            
-           this._fabricCanvas.absolutePan(new fabric.Point(canvasOffset.left-x,canvasOffset.top-y));
+           var pageScroll = OpenSeadragon.getPageScroll();
+           
+           this._fabricCanvas.absolutePan(new fabric.Point(canvasOffset.left - x + pageScroll.x, canvasOffset.top - y + pageScroll.y));
            
        }
         


### PR DESCRIPTION
if window page is not at position (0,0), the fabric overlay positions won't be correct by zooming in or out.
