### PR TITLE
adds ability to specify static canvas

### DIFF
--- a/openseadragon-fabricjs-overlay.js
+++ b/openseadragon-fabricjs-overlay.js
@@ -18,7 +18,7 @@
     OpenSeadragon.Viewer.prototype.fabricjsOverlay = function(options) {
 
 
-        this._fabricjsOverlayInfo = new Overlay(this);
+        this._fabricjsOverlayInfo = new Overlay(this, options.static);
         this._fabricjsOverlayInfo._scale = options.scale;
 
         return this._fabricjsOverlayInfo;
@@ -32,7 +32,7 @@
         }
     })();
     // ----------
-    var Overlay = function(viewer) {
+    var Overlay = function(viewer, staticCanvas) {
         var self = this;
 
         this._viewer = viewer;
@@ -54,7 +54,15 @@
         this._canvas.setAttribute('id', this._id);
         this._canvasdiv.appendChild(this._canvas);
         this.resize();
-        this._fabricCanvas=new fabric.Canvas(this._canvas);
+
+        // make the canvas static if specified, ordinary otherwise
+        if(staticCanvas) {
+            this._fabricCanvas=new fabric.StaticCanvas(this._canvas);
+        }
+        else {
+            this._fabricCanvas=new fabric.Canvas(this._canvas);
+        }
+
         // disable fabric selection because default click is tracked by OSD
         this._fabricCanvas.selection=false;
         // prevent OSD click elements on fabric objects


### PR DESCRIPTION
This commit adds a 'static' option to the fabricjsOverlay(), allowing users to make a static canvas if the desire.  The argument is completely optional, and if not specified does not change behavior, ensuring reverse compatibility.