### PR TITLE
Provide pointer event option to fabric canvas

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -7,7 +7,7 @@
     <script src="openseadragon-fabricjs-overlay.js"></script>
 
     <script src="//code.jquery.com/jquery-1.11.2.min.js"></script>
-    <script src="fabric/fabric.adapted.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/fabric.js/4.4.0/fabric.min.js"></script>
     <style type="text/css">
         html,
         body,

--- a/openseadragon-fabricjs-overlay.js
+++ b/openseadragon-fabricjs-overlay.js
@@ -51,7 +51,8 @@
      * @param viewer
      * @constructor
      */
-    let Overlay = function (viewer, staticCanvas) {
+    let Overlay = function (viewer, staticCanvas, fabricCanvasOptions = {}) {
+        fabricCanvasOptions.enablePointerEvents = true;
         let self = this;
 
         this._viewer = viewer;
@@ -76,10 +77,10 @@
 
         // make the canvas static if specified, ordinary otherwise
         if (staticCanvas) {
-            this._fabricCanvas = new fabric.StaticCanvas(this._canvas);
+            this._fabricCanvas = new fabric.StaticCanvas(this._canvas, fabricCanvasOptions);
         }
         else {
-            this._fabricCanvas = new fabric.Canvas(this._canvas);
+            this._fabricCanvas = new fabric.Canvas(this._canvas, fabricCanvasOptions);
         }
 
         // Disable fabric selection because default click is tracked by OSD

--- a/openseadragon-fabricjs-overlay.js
+++ b/openseadragon-fabricjs-overlay.js
@@ -52,7 +52,7 @@
      * @constructor
      */
     let Overlay = function (viewer, staticCanvas, fabricCanvasOptions = {}) {
-        fabricCanvasOptions.enablePointerEvents = true;
+        fabricCanvasOptions.enablePointerEvents = window.PointerEvent != null;
         let self = this;
 
         this._viewer = viewer;


### PR DESCRIPTION
I was trying to use the latest fabric (4.4.0, released yesterday of this issue), but it doesn't work.

After some digging, there were some changes for pointer mapping from this [commit],(https://github.com/altert/OpenseadragonFabricjsOverlay/commit/2eb46d5926f64407020e59845a46202b477009e9#diff-509a335d3130ce386c1b8bd54da76bc81b7d330f83b445c1797371f98874420c). 
followed by couple update to the fabric library in this project. 
![image](https://user-images.githubusercontent.com/10471270/114092618-f211a800-986e-11eb-8e70-3668026e0937.png)

I see this is unnecessary since fabric current has support for [pointer events](https://github.com/fabricjs/fabric.js/blob/2eabc92a3221dd628576b1bb029a5dc1156bdc06/src/mixins/canvas_events.mixin.js#L39) by providing `enablePointerEvents` as an option.

Based on the adapter code, if `window.PointerEvent` is availibe, use `pointer{event-name`, otherwise use `mouse{event-name}`.
I'm unsure if the `MSPointerEvent` is needed since the adapter itself is written in ES6, which is not supported on IE10 anyway. 

As a proof of concept, I made a simple change to provide `enablePointerEvents` in this library, and use the latest fabric 4.4.0 cdn in the demo page. It works.

If the project maintainers want to accept this pull request, we may as well remove the `/fabric` directory entirely.